### PR TITLE
docs: Add a warning in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 A Snakemake storage plugin for the LHCb [apd package](https://pypi.org/project/apd/).
 For documentation and usage instructions, see the [Snakemake plugin catalog](https://snakemake.github.io/snakemake-plugin-catalog/plugins/storage/apd.html).
+
+WIP -- this plugin is experimental and does not currently work with a released version of Snakemake!


### PR DESCRIPTION
Adds a warning in the README that this plugin is still in development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README to include a warning about the experimental status and compatibility limitations of the Snakemake storage plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->